### PR TITLE
feat: new option `exhaustive` and ignore node_modules by default

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,6 +9,7 @@ const knownOptions = {
   as: 'string',
   eager: 'boolean',
   export: 'string',
+  includeNodeModules: 'boolean',
 } as const
 
 const forceDefaultAs = ['raw', 'url']

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,7 +9,7 @@ const knownOptions = {
   as: 'string',
   eager: 'boolean',
   export: 'string',
-  includeNodeModules: 'boolean',
+  noIgnore: 'boolean',
 } as const
 
 const forceDefaultAs = ['raw', 'url']

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,7 +9,7 @@ const knownOptions = {
   as: 'string',
   eager: 'boolean',
   export: 'string',
-  noIgnore: 'boolean',
+  exhaustive: 'boolean',
 } as const
 
 const forceDefaultAs = ['raw', 'url']

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -41,7 +41,12 @@ export async function transform(
 
   const staticImports = (await Promise.all(
     matches.map(async({ absoluteGlobs, options, index, start, end }) => {
-      const files = (await fg(absoluteGlobs, { dot: true, absolute: true, cwd: root }))
+      const files = (await fg(absoluteGlobs, {
+        dot: true,
+        absolute: true,
+        cwd: root,
+        ignore: options.includeNodeModules ? [] : ['**/node_modules/**'],
+      }))
         .map((i) => {
           const path = relative(dir, i)
           if (path === filename)

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -42,10 +42,10 @@ export async function transform(
   const staticImports = (await Promise.all(
     matches.map(async({ absoluteGlobs, options, index, start, end }) => {
       const files = (await fg(absoluteGlobs, {
-        dot: !!options.noIgnore,
+        dot: !!options.exhaustive,
         absolute: true,
         cwd: root,
-        ignore: options.noIgnore ? [] : ['**/node_modules/**'],
+        ignore: options.exhaustive ? [] : ['**/node_modules/**'],
       }))
         .map((i) => {
           const path = relative(dir, i)

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -41,9 +41,9 @@ export async function transform(
   const staticImports = (await Promise.all(
     matches.map(async({ globsResolved, isRelative, options, index, start, end }) => {
       const files = (await fg(globsResolved, {
-        dot: !!options.exhaustive,
-        absolute: true,
         cwd: root,
+        absolute: true,
+        dot: !!options.exhaustive,
         ignore: options.exhaustive ? [] : ['**/node_modules/**'],
       }))
         .filter(file => file !== id)

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -42,10 +42,10 @@ export async function transform(
   const staticImports = (await Promise.all(
     matches.map(async({ absoluteGlobs, options, index, start, end }) => {
       const files = (await fg(absoluteGlobs, {
-        dot: true,
+        dot: !!options.noIgnore,
         absolute: true,
         cwd: root,
-        ignore: options.includeNodeModules ? [] : ['**/node_modules/**'],
+        ignore: options.noIgnore ? [] : ['**/node_modules/**'],
       }))
         .map((i) => {
           const path = relative(dir, i)

--- a/types.ts
+++ b/types.ts
@@ -17,6 +17,12 @@ export interface GlobOptions<Eager extends boolean, AsType extends string> {
    * Custom queries
    */
   query?: string | Record<string, string | number | boolean>
+  /**
+   * Also search for files inside `/node_modules/`. BECAREFUL: this is slow.
+   *
+   * @default false
+   */
+  includeNodeModules?: boolean
 }
 
 export type GeneralGlobOptions = GlobOptions<boolean, string>

--- a/types.ts
+++ b/types.ts
@@ -18,11 +18,11 @@ export interface GlobOptions<Eager extends boolean, AsType extends string> {
    */
   query?: string | Record<string, string | number | boolean>
   /**
-   * Also search for files inside `/node_modules/`. BECAREFUL: this is slow.
+   * Search files also inside `node_modules/` and hidden directories (e.g. `.git/`). BECAREFUL: this is slow.
    *
    * @default false
    */
-  includeNodeModules?: boolean
+  noIgnore?: boolean
 }
 
 export type GeneralGlobOptions = GlobOptions<boolean, string>

--- a/types.ts
+++ b/types.ts
@@ -22,7 +22,7 @@ export interface GlobOptions<Eager extends boolean, AsType extends string> {
    *
    * @default false
    */
-  noIgnore?: boolean
+  exhaustive?: boolean
 }
 
 export type GeneralGlobOptions = GlobOptions<boolean, string>


### PR DESCRIPTION
Eventually, a user will forget to add `node_modules` to the ignore paths. This prevents it from happening.