### PR TITLE
perf: automatically reduce search space

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { scan } from 'micromatch'
+
 const cssLangs = '\\.(css|less|sass|scss|styl|stylus|pcss|postcss)($|\\?)'
 const cssLangRE = new RegExp(cssLangs)
 
@@ -14,4 +16,21 @@ export function assert(condition: unknown): asserts condition {
       'Reach out at https://github.com/antfu/vite-plugin-glob/issues/new and include this error stack (the error stack is usually enough to fix the problem).',
     ].join(' '),
   )
+}
+
+export function getCommonBase(globsResolved: string[]): null | string {
+  const bases = globsResolved.filter(g => !g.startsWith('!')).map(glob => scan(glob).base)
+  if (!bases.length)
+    return null
+
+  let commonAncestor = '/'
+  const dirS = bases[0].split('/')
+  for (let i = 0; i < dirS.length; i++) {
+    const candidate = dirS.slice(0, i + 1).join('/')
+    if (bases.every(base => base.startsWith(candidate)))
+      commonAncestor = candidate
+    else
+      break
+  }
+  return commonAncestor
 }

--- a/test/fixture.test.ts
+++ b/test/fixture.test.ts
@@ -80,6 +80,16 @@ describe('fixture', async() => {
         \\"/takeover.d.ts\\": () => import(\\"../../takeover.d.ts?url?url&lang.ts\\").then(m => m[\\"default\\"]),
         \\"/types.ts\\": () => import(\\"../../types.ts?url?url&lang.ts\\").then(m => m[\\"default\\"])
         }
+        
+        export const cleverCwd1 = {
+        \\"./node_modules/framework/pages/hello.page.js\\": () => import(\\"./node_modules/framework/pages/hello.page.js\\")
+        }
+        
+        export const cleverCwd2 = {
+        \\"../../playground/src/main.ts\\": () => import(\\"../../playground/src/main.ts\\"),
+        \\"./modules/a.ts\\": () => import(\\"./modules/a.ts\\"),
+        \\"./modules/b.ts\\": () => import(\\"./modules/b.ts\\")
+        }
         "
       `)
   })

--- a/test/fixtures/.gitignore
+++ b/test/fixtures/.gitignore
@@ -1,0 +1,1 @@
+!/node_modules/

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -37,3 +37,11 @@ export const rootMixedRelative = import.meta.glob([
   '/*.ts',
   '../../playground/*.json',
 ], { as: 'url' })
+
+export const cleverCwd1 = import.meta.glob('./node_modules/framework/**/*.page.js')
+
+export const cleverCwd2 = import.meta.glob([
+  './modules/*.ts',
+  '../../playground/src/*.ts',
+  '!**/index.ts',
+])

--- a/test/fixtures/node_modules/framework/pages/hello.page.js
+++ b/test/fixtures/node_modules/framework/pages/hello.page.js
@@ -1,0 +1,2 @@
+// A fake Page file. (This technique of globbing into `node_modules/`
+// is used by vite-plugin-ssr frameworks and Hydrogen.)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -8,13 +8,20 @@ describe('getCommonBase()', async() => {
   it('common base', () => {
     expect(getCommonBase(['/a/b/**/*.vue', '/a/b/**/*.jsx'])).toBe('/a/b')
   })
-  it('static file - 1', () => {
+  it('static file', () => {
     expect(getCommonBase(['/a/b/**/*.vue', '/a/b/**/*.jsx', '/a/b/foo.js'])).toBe('/a/b')
-  })
-  it('static file - 2', () => {
     expect(getCommonBase(['/a/b/**/*.vue', '/a/b/**/*.jsx', '/a/foo.js'])).toBe('/a')
   })
   it('correct `scan()`', () => {
+    expect(getCommonBase(['/a/*.vue'])).toBe('/a')
+    expect(getCommonBase(['/a/some.vue'])).toBe('/a')
     expect(getCommonBase(['/a/b/**/c/foo.vue', '/a/b/c/**/*.jsx'])).toBe('/a/b')
+  })
+  it('single', () => {
+    expect(getCommonBase(['/a/b/c/*.vue'])).toBe('/a/b/c')
+    expect(getCommonBase(['/a/b/c/foo.vue'])).toBe('/a/b/c')
+  })
+  it('no common base', () => {
+    expect(getCommonBase(['/a/b/*.js', '/c/a/b/*.js'])).toBe('/')
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { getCommonBase } from '../src/utils'
+
+describe('getCommonBase()', async() => {
+  it('basic', () => {
+    expect(getCommonBase(['/a/b/*.js', '/a/c/*.js'])).toBe('/a')
+  })
+  it('common base', () => {
+    expect(getCommonBase(['/a/b/**/*.vue', '/a/b/**/*.jsx'])).toBe('/a/b')
+  })
+  it('static file - 1', () => {
+    expect(getCommonBase(['/a/b/**/*.vue', '/a/b/**/*.jsx', '/a/b/foo.js'])).toBe('/a/b')
+  })
+  it('static file - 2', () => {
+    expect(getCommonBase(['/a/b/**/*.vue', '/a/b/**/*.jsx', '/a/foo.js'])).toBe('/a')
+  })
+  it('correct `scan()`', () => {
+    expect(getCommonBase(['/a/b/**/c/foo.vue', '/a/b/c/**/*.jsx'])).toBe('/a/b')
+  })
+})


### PR DESCRIPTION
Not only does this considerably increase performance, but it also enables globbing into `node_modules/` while preserving `ignore: ['**/node_modules/**']`.

Both Hydrogen and vps frameworks need globs such as  `node_modules/framework/**/*.page.js`.