### PR TITLE
fix: importer being a virtual module

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,7 +16,7 @@ const forceDefaultAs = ['raw', 'url']
 
 export async function parseImportGlob(
   code: string,
-  dir: string,
+  dir: string | null,
   root: string,
   resolveId: (id: string) => string | Promise<string>,
 ): Promise<ParsedImportGlob[]> {
@@ -149,7 +149,7 @@ export async function parseImportGlob(
 
     const end = ast.range![1]
 
-    const globsResolved = await Promise.all(globs.map(glob => toAbsoluteGlob(glob, root, dir, resolveId)))
+    const globsResolved = await Promise.all(globs.map(glob => toAbsoluteGlob(glob, root, dir ?? root, resolveId)))
     const isRelative = globs.every(i => '.!'.includes(i[0]))
 
     return {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -69,6 +69,9 @@ export async function transform(
 
       const resolvePaths = (file: string) => {
         if (!dir) {
+          if (isRelative)
+            throw new Error('In virtual modules, all globs must start with \'/\'')
+
           let filePath = relative(root, file)
           if (!filePath.startsWith('.'))
             filePath = `/${filePath}`

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -4,7 +4,7 @@ import fg from 'fast-glob'
 import { stringifyQuery } from 'ufo'
 import type { PluginOptions } from '../types'
 import { parseImportGlob } from './parse'
-import { getCommonBase, isCSSRequest, toPosixPath } from './utils'
+import { getCommonBase, isCSSRequest, isVirtualModule, toPosixPath } from './utils'
 
 const importPrefix = '__vite_glob_next_'
 
@@ -19,7 +19,7 @@ export async function transform(
 ) {
   id = toPosixPath(id)
   root = toPosixPath(root)
-  const dir = !id.includes('/') ? null : dirname(id)
+  const dir = isVirtualModule(id) ? null : dirname(id)
   let matches = await parseImportGlob(code, dir, root, resolveId)
 
   if (options?.takeover) {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -19,7 +19,7 @@ export async function transform(
 ) {
   id = toPosixPath(id)
   root = toPosixPath(root)
-  const dir = dirname(id)
+  const dir = !id.includes('/') ? null : dirname(id)
   let matches = await parseImportGlob(code, dir, root, resolveId)
 
   if (options?.takeover) {
@@ -68,6 +68,13 @@ export async function transform(
         query = `?${query}`
 
       const resolvePaths = (file: string) => {
+        if (!dir) {
+          let filePath = relative(root, file)
+          if (!filePath.startsWith('.'))
+            filePath = `/${filePath}`
+          return { filePath, importPath: filePath }
+        }
+
         let importPath = relative(dir, file)
         if (!importPath.startsWith('.'))
           importPath = `./${importPath}`

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -71,10 +71,7 @@ export async function transform(
         if (!dir) {
           if (isRelative)
             throw new Error('In virtual modules, all globs must start with \'/\'')
-
-          let filePath = relative(root, file)
-          if (!filePath.startsWith('.'))
-            filePath = `/${filePath}`
+          const filePath = `/${relative(root, file)}`
           return { filePath, importPath: filePath }
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,3 +38,8 @@ export function getCommonBase(globsResolved: string[]): null | string {
 export function toPosixPath(p: string) {
   return p.split('\\').join('/')
 }
+
+export function isVirtualModule(id: string) {
+  // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
+  return id.startsWith('virtual:') || id.startsWith('\0') || !id.includes('/')
+}

--- a/test/fixture.test.ts
+++ b/test/fixture.test.ts
@@ -5,12 +5,15 @@ import { transformWithEsbuild } from 'vite'
 import { transform } from '../src/transform'
 
 describe('fixture', async() => {
+  const resolveId = (id: string) => id
+  const options = { takeover: true }
+
   it('transform', async() => {
     const id = resolve(__dirname, './fixtures/index.ts')
     const code = (await transformWithEsbuild(await fs.readFile(id, 'utf-8'), id)).code
     const root = process.cwd()
 
-    expect((await transform(code, id, root, id => id, { takeover: true }))?.s.toString())
+    expect((await transform(code, id, root, resolveId, options))?.s.toString())
       .toMatchInlineSnapshot(`
         "import * as __vite_glob_next_1_0 from \\"./modules/a.ts\\"
         import * as __vite_glob_next_1_1 from \\"./modules/b.ts\\"
@@ -78,5 +81,25 @@ describe('fixture', async() => {
         };
         "
       `)
+  })
+
+  it('virtual modules', async() => {
+    const root = resolve(__dirname, './fixtures')
+    expect((await transform('import.meta.glob(\'/modules/*.ts\')', 'virtual:module', root, resolveId, options))?.s.toString())
+      .toMatchInlineSnapshot(`
+"{
+\\"/modules/a.ts\\": () => import(\\"/modules/a.ts\\"),
+\\"/modules/b.ts\\": () => import(\\"/modules/b.ts\\"),
+\\"/modules/index.ts\\": () => import(\\"/modules/index.ts\\")
+}"`,
+      )
+
+    try {
+      await transform('import.meta.glob(\'./modules/*.ts\')', 'virtual:module', root, resolveId, options)
+      expect('no error').toBe('should throw an error')
+    }
+    catch (err) {
+      expect(err).toMatchInlineSnapshot('[Error: In virtual modules, all globs must start with \'/\']')
+    }
   })
 })

--- a/test/fixture.test.ts
+++ b/test/fixture.test.ts
@@ -85,12 +85,21 @@ describe('fixture', async() => {
 
   it('virtual modules', async() => {
     const root = resolve(__dirname, './fixtures')
-    expect((await transform('import.meta.glob(\'/modules/*.ts\')', 'virtual:module', root, resolveId, options))?.s.toString())
+    const code = [
+      'import.meta.glob(\'/modules/*.ts\')',
+      'import.meta.glob([\'/../../playground/src/fixtures/*.ts\'])',
+    ].join('\n')
+    expect((await transform(code, 'virtual:module', root, resolveId, options))?.s.toString())
       .toMatchInlineSnapshot(`
 "{
 \\"/modules/a.ts\\": () => import(\\"/modules/a.ts\\"),
 \\"/modules/b.ts\\": () => import(\\"/modules/b.ts\\"),
 \\"/modules/index.ts\\": () => import(\\"/modules/index.ts\\")
+}
+{
+\\"/../../playground/src/fixtures/a.ts\\": () => import(\\"/../../playground/src/fixtures/a.ts\\"),
+\\"/../../playground/src/fixtures/b.ts\\": () => import(\\"/../../playground/src/fixtures/b.ts\\"),
+\\"/../../playground/src/fixtures/index.ts\\": () => import(\\"/../../playground/src/fixtures/index.ts\\")
 }"`,
       )
 


### PR DESCRIPTION
When the importer is a virtual module, there is no current directory and vite-plugin-glob fails. This PR fixes it.